### PR TITLE
nsamp may be 0 or negative in the function make_cluster

### DIFF
--- a/imf/imf.py
+++ b/imf/imf.py
@@ -667,7 +667,8 @@ def make_cluster(mcluster, massfunc='kroupa', verbose=False, silent=False,
 
     while mtot < mcluster + tolerance:
         # at least 1 sample, but potentially many more
-        nsamp = np.ceil((mcluster-mtot) / expected_mass)
+        nsamp = np.ceil((mcluster+tolerance-mtot) / expected_mass)
+        assert nsamp > 0
         newmasses = inverse_imf(np.random.random(int(nsamp)), massfunc=massfunc, **kwargs)
         masses = np.concatenate([masses,newmasses])
         mtot = masses.sum()


### PR DESCRIPTION
Hi Adam, I am trying to use your code to generate cluster masses, but sometimes it falls into an infinite loop, because nsamp happens to be intialized as 0, or has an error like "ValueError: negative dimensions are not allowed", because nsamp is intialized as a negative number. This could happen if mtot is very close to mcluster, or mtot > mcluster but mtot < mcluster + tolerance.
I tried the following parameters and about 5 in 10 times the above issue occurs:
imf.make_cluster(400.,tolerance = 5., verbose = True, stop_criterion='nearest', mmax = 150.)