### PR TITLE
implement the percentile point functions (inverse of cdf)

### DIFF
--- a/imf/distributions.py
+++ b/imf/distributions.py
@@ -232,17 +232,22 @@ class CompositeDistribution(Distribution):
         weights = [1]
         breaks = [_.m1 for _ in self.distrs] + [self.distrs[-1].m2]
 
-        self.m1 = breaks[0]
-        self.m2 = breaks[-1]
+        self.m1 = breaks[0]  # leftmost edge
+        self.m2 = breaks[-1]  # rightmost edge
+
+        # check that edges of intervals match
         for ii in range(1, nsegm):
             assert (distrs[ii].m1 == distrs[ii - 1].m2)
 
         for ii in range(1, nsegm):
             rat = distrs[ii].pdf(breaks[ii]) / distrs[ii - 1].pdf(breaks[ii])
+            # relative normalization of next pdf to the previous one so they
+            # join without a break
             weights.append(weights[-1] / rat)
         weights = np.array(weights)
         self.breaks = breaks
         self.weights = weights / np.sum(weights)
+        # these are relative weights  of each pdf
         self.nsegm = nsegm
 
     def pdf(self, x):
@@ -274,7 +279,9 @@ class CompositeDistribution(Distribution):
         for ii in range(self.nsegm):
             if Ns[ii] > 0:
                 ret.append(self.distrs[ii].rvs(Ns[ii]))
-        return np.concatenate(ret)
+        ret = np.concatenate(ret)
+        ret = np.random.permutation(ret)  # permutation
+        return ret
 
     def ppf(self, x0):
         x = np.asarray(x0)

--- a/imf/distributions.py
+++ b/imf/distributions.py
@@ -1,25 +1,31 @@
 import numpy as np
 import scipy.stats
 
+
 class Distribution:
     """ The main class describing the distributions, to be inherited"""
     def __init__(self):
-        self.m1=0 # edges of the support of the pdf
-        self.m2=np.inf
+        self.m1 = 0  # edges of the support of the pdf
+        self.m2 = np.inf
         pass
-    def pdf(self,x):
+
+    def pdf(self, x):
         """ Return the Probability density function"""
         pass
+
     def cdf(self, x):
         """ Cumulative distribtuion function """
         pass
+
     def rvs(self, N):
         """ Generate random sample """
         pass
-    def ppf(self,x):
+
+    def ppf(self, x):
         #inverse cdf
         raise RuntimeError('not implemented')
         pass
+
 
 class LogNormal(Distribution):
     def __init__(self, mu, sig):
@@ -45,6 +51,7 @@ class LogNormal(Distribution):
     def ppf(self, x):
         return self.d.ppf(x)
 
+
 class TruncatedLogNormal:
     def __init__(self, mu, sig, m1, m2):
         """ Standard log-normal but truncated in the interval m1,m2 """
@@ -57,16 +64,18 @@ class TruncatedLogNormal:
         return self.d.pdf(x) * (x >= self.m1) * (x <= self.m2) / self.norm
 
     def cdf(self, x):
-        return (self.d.cdf(np.clip(x,self.m1,self.m2)) - self.d.cdf(self.m1)) / self.norm
+        return (self.d.cdf(np.clip(x, self.m1, self.m2)) -
+                self.d.cdf(self.m1)) / self.norm
 
     def rvs(self, N):
         x = np.random.uniform(self.d.cdf(self.m1), self.d.cdf(self.m2), size=N)
         return self.d.ppf(x)
 
-    def ppf(self,x):
+    def ppf(self, x):
         cut1 = self.d.cdf(self.m1)
         cut2 = self.d.cdf(self.m2)
-        return self.d.ppf(x*(cut2-cut1)+cut1)
+        return self.d.ppf(x * (cut2 - cut1) + cut1)
+
 
 class PowerLaw(Distribution):
     def __init__(self, slope, m1, m2):
@@ -74,15 +83,14 @@ class PowerLaw(Distribution):
         self.slope = slope
         self.m1 = float(m1)
         self.m2 = float(m2)
-        assert(m1 < m2)
-        assert(m1 > 0)
-        assert(m1 != -1)
+        assert (m1 < m2)
+        assert (m1 > 0)
+        assert (m1 != -1)
 
     def pdf(self, x):
         if self.slope == -1:
-            return (x**self.slope
-                    / (np.log(self.m2/self.m1))
-                    * (x >= self.m1) * (x <= self.m2))
+            return (x**self.slope / (np.log(self.m2 / self.m1)) *
+                    (x >= self.m1) * (x <= self.m2))
         else:
             return x**self.slope * (self.slope + 1) / (
                 self.m2**(self.slope + 1) -
@@ -95,17 +103,19 @@ class PowerLaw(Distribution):
             return (np.clip(x, self.m1, self.m2)**(self.slope + 1) -
                     (self.m1**(self.slope + 1))) / (self.m2**(self.slope + 1) -
                                                     self.m1**(self.slope + 1))
+
     def rvs(self, N):
         x = np.random.uniform(size=N)
         return self.ppf(x)
 
     def ppf(self, x):
         if self.slope == -1:
-            return np.exp(x * np.log(self.m2/self.m1)) * self.m1
+            return np.exp(x * np.log(self.m2 / self.m1)) * self.m1
         else:
-            return(x * (self.m2**(self.slope+1) - self.m1**(self.slope+1))
-                   + self.m1**(self.slope+1))**(1./(self.slope+1))
-        
+            return (x *
+                    (self.m2**(self.slope + 1) - self.m1**(self.slope + 1)) +
+                    self.m1**(self.slope + 1))**(1. / (self.slope + 1))
+
 
 class BrokenPowerLaw:
     def __init__(self, slopes, breaks):
@@ -120,7 +130,7 @@ class BrokenPowerLaw:
             then the list of slopes
         """
         assert (len(slopes) == len(breaks) - 1)
-        assert ((np.diff(breaks)>0).all())
+        assert ((np.diff(breaks) > 0).all())
         nsegm = len(slopes)
         pows = []
         for ii in range(nsegm):
@@ -133,7 +143,7 @@ class BrokenPowerLaw:
         self.slopes = slopes
         self.breaks = breaks
         self.pows = pows
-        self.weights = weights / np.sum(weights) # relative normalizations
+        self.weights = weights / np.sum(weights)  # relative normalizations
         self.nsegm = nsegm
         self.m1 = breaks[0]
         self.m2 = breaks[-1]
@@ -160,34 +170,35 @@ class BrokenPowerLaw:
         xind = x1 >= self.breaks[-1]
 
         if np.any(xind):
-            ret[xind]=1
+            ret[xind] = 1
 
         return ret.reshape(x1.shape)
 
     def rvs(self, N):
         Ns = np.random.multinomial(N, self.weights)
-        ret=[]
+        ret = []
         for ii in range(self.nsegm):
-            if Ns[ii]>0:
+            if Ns[ii] > 0:
                 ret.append(self.pows[ii].rvs(Ns[ii]))
         return np.concatenate(ret)
 
     def ppf(self, x0):
         x = np.asarray(x0)
-        x1 =np.atleast_1d(x)
-        assert(x1.min()>=0)
-        assert(x1.max()<=1)
-        edges = np.r_[[0],np.cumsum(self.weights)]
+        x1 = np.atleast_1d(x)
+        assert (x1.min() >= 0)
+        assert (x1.max() <= 1)
+        edges = np.r_[[0], np.cumsum(self.weights)]
         # edges of powerlaw in CDF scale from 0 to 1
-        pos = np.digitize(x1, edges) # bin positions, 1 is the leftmost 
-        left = edges[pos-1]
-        w = self.weights[pos-1]
-        x2 = np.clip((x1-left)/w,0,1) # mapping to 0,1 on the segment
-        ret =np.zeros_like(x1)
+        pos = np.digitize(x1, edges)  # bin positions, 1 is the leftmost
+        left = edges[pos - 1]
+        w = self.weights[pos - 1]
+        x2 = np.clip((x1 - left) / w, 0, 1)  # mapping to 0,1 on the segment
+        ret = np.zeros_like(x1)
         for ii in range(x.size):
-            ret[ii] = self.pows[pos[ii]-1].ppf(x2[ii])
+            ret[ii] = self.pows[pos[ii] - 1].ppf(x2[ii])
         return ret.reshape(x.shape)
-    
+
+
 class CompositeDistribution(Distribution):
     def __init__(self, distrs):
         """ A Composite distribution that consists of several distributions
@@ -214,8 +225,8 @@ class CompositeDistribution(Distribution):
 
         self.m1 = breaks[0]
         self.m2 = breaks[-1]
-        for ii in range(1,nsegm):
-            assert(distrs[ii].m1==distrs[ii-1].m2)
+        for ii in range(1, nsegm):
+            assert (distrs[ii].m1 == distrs[ii - 1].m2)
 
         for ii in range(1, nsegm):
             rat = distrs[ii].pdf(breaks[ii]) / distrs[ii - 1].pdf(breaks[ii])
@@ -243,30 +254,30 @@ class CompositeDistribution(Distribution):
             if xind.sum() > 0:
                 ret[xind] = cums[ii] + self.weights[ii] * self.distrs[ii].cdf(
                     x1[xind])
-        xind = x1>self.breaks[-1]
+        xind = x1 > self.breaks[-1]
         if xind.sum():
-            ret[xind]=1
+            ret[xind] = 1
         return ret.reshape(x1.shape)
 
     def rvs(self, N):
         Ns = np.random.multinomial(N, self.weights)
-        ret=[]
+        ret = []
         for ii in range(self.nsegm):
-            if Ns[ii]>0:
+            if Ns[ii] > 0:
                 ret.append(self.distrs[ii].rvs(Ns[ii]))
         return np.concatenate(ret)
 
     def ppf(self, x0):
-        x= np.asarray(x0)
-        x1 =np.atleast_1d(x)
-        assert(x1.min()>=0)
-        assert(x1.max()<=1)
-        edges = np.r_[[0],np.cumsum(self.weights)]
+        x = np.asarray(x0)
+        x1 = np.atleast_1d(x)
+        assert (x1.min() >= 0)
+        assert (x1.max() <= 1)
+        edges = np.r_[[0], np.cumsum(self.weights)]
         pos = np.digitize(x1, edges)
-        left = edges[pos-1]
-        w = self.weights[pos-1]
-        x2 = np.clip((x1-left)/w,0,1) # mapping to 0,1 on the segment
-        ret =np.zeros_like(x1)
+        left = edges[pos - 1]
+        w = self.weights[pos - 1]
+        x2 = np.clip((x1 - left) / w, 0, 1)  # mapping to 0,1 on the segment
+        ret = np.zeros_like(x1)
         for ii in range(x.size):
-            ret[ii] = self.distrs[pos[ii]-1].ppf(x2[ii])
+            ret[ii] = self.distrs[pos[ii] - 1].ppf(x2[ii])
         return ret.reshape(x.shape)

--- a/imf/tests/test_distributions.py
+++ b/imf/tests/test_distributions.py
@@ -5,11 +5,13 @@ from .. import imf
 from .. import distributions as D
 
 
-def test_distr():
+def test_lognorm():
     ln = D.LogNormal(1, 1)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    assert (np.abs(ln.ppf(ln.cdf(2))-2)<1e-5)
+    # test that ppf is inverse of cdf
 
     for i in range(10):
         N = 100000
@@ -21,21 +23,30 @@ def test_distr():
         assert(np.abs(np.log(samp).mean()-np.log(mean))< 0.01*sig)
         assert(np.abs(np.log(samp).std()-sig)< 0.01*sig)
 
+def test_broken_plaw():
+    ln = D.BrokenPowerLaw([-2, -1.1, -3], [0.1, 1, 2, 100])
+    ln.pdf(1.)
+    ln.cdf(1)
+    ln.rvs(1000)
+    assert (np.abs(ln.ppf(ln.cdf(0.5))-0.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(1.5))-1.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
+
+
+def test_distr():
     ln = D.TruncatedLogNormal(1, 1, 2, 3)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
 
     ln = D.PowerLaw(-2, 2, 6)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    assert (np.abs(ln.ppf(ln.cdf(3))-3)<1e-5)
 
-    ln = D.BrokenPowerLaw([-2, -1.1, -3], [0.1, 1, 2, 100])
-    ln.pdf(1.)
-    ln.cdf(1)
-    ln.rvs(1000)
-
+def test_composite():
     ln = D.CompositeDistribution([
         D.TruncatedLogNormal(1, 1, 2, 3),
         D.PowerLaw(-2, 3, 4),
@@ -45,6 +56,10 @@ def test_distr():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(3.5))-3.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(4.5))-4.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(5.5))-5.5)<1e-5)
 
 
 def test_bounds():

--- a/imf/tests/test_distributions.py
+++ b/imf/tests/test_distributions.py
@@ -5,13 +5,23 @@ from .. import imf
 from .. import distributions as D
 
 
+def ppftest(distr):
+    # test that ppf is inverse of cdf
+    xs = np.random.uniform(0, 1, size=100)
+    eps = 1e-5
+    assert (np.all(np.abs(distr.cdf(distr.ppf(xs)) - xs) < eps))
+    # test on scalar
+    assert (np.abs(distr.cdf(distr.ppf(xs[0])) - xs[0]) < eps)
+    assert (np.isnan(distr.ppf(-0.1)))
+    assert (np.isnan(distr.ppf(1.1)))
+
+
 def test_lognorm():
     ln = D.LogNormal(1, 1)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(2)) - 2) < 1e-5)
-    # test that ppf is inverse of cdf
+    ppftest(ln)
 
     for i in range(10):
         N = 100000
@@ -29,6 +39,9 @@ def test_broken_plaw():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    ppftest(ln)
+
+    # test values in each range
     assert (np.abs(ln.ppf(ln.cdf(0.5)) - 0.5) < 1e-5)
     assert (np.abs(ln.ppf(ln.cdf(1.5)) - 1.5) < 1e-5)
     assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
@@ -39,13 +52,12 @@ def test_distr():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
-
+    ppftest(ln)
     ln = D.PowerLaw(-2, 2, 6)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(3)) - 3) < 1e-5)
+    ppftest(ln)
 
 
 def test_composite():
@@ -58,6 +70,8 @@ def test_composite():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
+    ppftest(ln)
+    # test values in each break
     assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
     assert (np.abs(ln.ppf(ln.cdf(3.5)) - 3.5) < 1e-5)
     assert (np.abs(ln.ppf(ln.cdf(4.5)) - 4.5) < 1e-5)

--- a/imf/tests/test_distributions.py
+++ b/imf/tests/test_distributions.py
@@ -10,27 +10,28 @@ def test_lognorm():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(2))-2)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(2)) - 2) < 1e-5)
     # test that ppf is inverse of cdf
 
     for i in range(10):
         N = 100000
-        mean = np.random.uniform(0.1,10)
-        sig = np.random.uniform(0.1,10)
+        mean = np.random.uniform(0.1, 10)
+        sig = np.random.uniform(0.1, 10)
         ln2 = D.LogNormal(mean, sig)
         samp = ln2.rvs(N)
         # check that the means and sigmas are correct
-        assert(np.abs(np.log(samp).mean()-np.log(mean))< 0.01*sig)
-        assert(np.abs(np.log(samp).std()-sig)< 0.01*sig)
+        assert (np.abs(np.log(samp).mean() - np.log(mean)) < 0.01 * sig)
+        assert (np.abs(np.log(samp).std() - sig) < 0.01 * sig)
+
 
 def test_broken_plaw():
     ln = D.BrokenPowerLaw([-2, -1.1, -3], [0.1, 1, 2, 100])
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(0.5))-0.5)<1e-5)
-    assert (np.abs(ln.ppf(ln.cdf(1.5))-1.5)<1e-5)
-    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(0.5)) - 0.5) < 1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(1.5)) - 1.5) < 1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
 
 
 def test_distr():
@@ -38,13 +39,14 @@ def test_distr():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
 
     ln = D.PowerLaw(-2, 2, 6)
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(3))-3)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(3)) - 3) < 1e-5)
+
 
 def test_composite():
     ln = D.CompositeDistribution([
@@ -56,10 +58,10 @@ def test_composite():
     ln.pdf(1.)
     ln.cdf(1)
     ln.rvs(1000)
-    assert (np.abs(ln.ppf(ln.cdf(2.5))-2.5)<1e-5)
-    assert (np.abs(ln.ppf(ln.cdf(3.5))-3.5)<1e-5)
-    assert (np.abs(ln.ppf(ln.cdf(4.5))-4.5)<1e-5)
-    assert (np.abs(ln.ppf(ln.cdf(5.5))-5.5)<1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(2.5)) - 2.5) < 1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(3.5)) - 3.5) < 1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(4.5)) - 4.5) < 1e-5)
+    assert (np.abs(ln.ppf(ln.cdf(5.5)) - 5.5) < 1e-5)
 
 
 def test_bounds():


### PR DESCRIPTION
Hi, 

I've implemented the PPF (percentile point function; inverse of CDF) for all the distributions. They are useful for example for sampling (i.e. nested sampling where you need to convert your prior into uniform from zero to one). 
I've also added tests that they work as inverse as CDFs. 

   Sergey