### PR TITLE
Fixes

### DIFF
--- a/imf/distributions.py
+++ b/imf/distributions.py
@@ -137,8 +137,12 @@ class BrokenPowerLaw:
             Array of points/edges of powerlaw segments must be larger by one
             then the list of slopes
         """
-        assert (len(slopes) == len(breaks) - 1)
-        assert ((np.diff(breaks) > 0).all())
+        if not (len(slopes) == len(breaks) - 1):
+            raise ValueError(
+                'The length of array of slopes must be equal to length of ' +
+                'array of break points minus 1')
+        if not ((np.diff(breaks) > 0).all()):
+            raise ValueError('Power law break-points must be uniform')
         self.slopes = slopes
         self.breaks = breaks
         self._calcpows()
@@ -168,7 +172,9 @@ class BrokenPowerLaw:
         nsegm = len(self.slopes)
         pows = []
         for ii in range(nsegm):
-            pows.append(PowerLaw(self.slopes[ii], self.breaks[ii], self.breaks[ii + 1]))
+            pows.append(
+                PowerLaw(self.slopes[ii], self.breaks[ii],
+                         self.breaks[ii + 1]))
         self.pows = pows
         self.nsegm = nsegm
 
@@ -176,7 +182,8 @@ class BrokenPowerLaw:
         nsegm = len(self.slopes)
         weights = [1]
         for ii in range(1, nsegm):
-            rat = self.pows[ii].pdf(self.breaks[ii]) / self.pows[ii - 1].pdf(self.breaks[ii])
+            rat = self.pows[ii].pdf(self.breaks[ii]) / self.pows[ii - 1].pdf(
+                self.breaks[ii])
             weights.append(weights[-1] / rat)
         weights = np.array(weights)
         self.weights = weights / np.sum(weights)  # relative normalizations

--- a/imf/distributions.py
+++ b/imf/distributions.py
@@ -137,12 +137,6 @@ class BrokenPowerLaw:
             Array of points/edges of powerlaw segments must be larger by one
             then the list of slopes
         """
-        if not (len(slopes) == len(breaks) - 1):
-            raise ValueError(
-                'The length of array of slopes must be equal to length of ' +
-                'array of break points minus 1')
-        if not ((np.diff(breaks) > 0).all()):
-            raise ValueError('Power law break-points must be uniform')
         self.slopes = slopes
         self.breaks = breaks
         self._calcpows()
@@ -169,6 +163,12 @@ class BrokenPowerLaw:
         self._calcweights()
 
     def _calcpows(self):
+        if not (len(self.slopes) == len(self.breaks) - 1):
+            raise ValueError(
+                'The length of array of slopes must be equal to length of ' +
+                'array of break points minus 1')
+        if not ((np.diff(self.breaks) > 0).all()):
+            raise ValueError('Power law break-points must be monotonic')
         nsegm = len(self.slopes)
         pows = []
         for ii in range(nsegm):

--- a/imf/imf.py
+++ b/imf/imf.py
@@ -189,12 +189,30 @@ class Kroupa(MassFunction):
 
 class Chabrier(MassFunction):
     def __init__(self):
-        self.mmin = 0.57 * np.log(10)
+        self.m0 = 0.57 * np.log(10)
         self.multiplier = 0.86
+        mmin = 0
+        mmax = np.inf
+        self.distr = distributions.TruncatedLogNormal(0.22, self.m0, mmin,
+                                                      mmax)
+        self.mmin = mmin
+        self.mmax = mmax
 
     @property
-    def distr(self):
-        return distributions.LogNormal(0.22, self.mmin)
+    def mmin(self):
+        return self.distr.m1
+
+    @mmin.setter
+    def mmin(self, value):
+        self.distr.m1 = value
+
+    @property
+    def mmax(self):
+        return self.distr.m2
+
+    @mmax.setter
+    def mmax(self, value):
+        self.distr.m2 = value
 
     def __call__(self, mass, integral_form=False, **kw):
         if integral_form:

--- a/imf/imf.py
+++ b/imf/imf.py
@@ -20,7 +20,6 @@ class MassFunction(object):
 
     (this is mostly meant to be subclassed by other functions, not used itself)
     """
-
     def dndm(self, m, **kwargs):
         """
         The differential form of the mass function, d N(M) / dM
@@ -52,6 +51,7 @@ class MassFunction(object):
     def log_integrate(self, mlow, mhigh, **kwargs):
         def logform(x):
             return self(x) / x
+
         return scipy.integrate.quad(logform, mlow, mhigh, **kwargs)
 
     def normalize(self, mmin=None, mmax=None, log=False, **kwargs):
@@ -70,13 +70,12 @@ class MassFunction(object):
             integral = self.log_integrate(mmin, mmax, **kwargs)
         else:
             integral = self.integrate(mmin, mmax, **kwargs)
-        self.normfactor = 1./integral[0]
+        self.normfactor = 1. / integral[0]
 
         assert self.normfactor > 0
 
 
 class Salpeter(MassFunction):
-
     def __init__(self, alpha=2.35, mmin=0.3, mmax=120):
         """
         Create a default Salpeter mass function, i.e. a power-law mass function
@@ -106,8 +105,14 @@ salpeter = Salpeter()
 
 class Kroupa(MassFunction):
     # kroupa = BrokenPowerLaw(breaks={0.08: -0.3, 0.5: 1.3, 'last': 2.3}, mmin=0.03, mmax=120)
-    def __init__(self, mmin=0.03, mmax=120, p1=0.3, p2=1.3, p3=2.3,
-                 break1=0.08, break2=0.5):
+    def __init__(self,
+                 mmin=0.03,
+                 mmax=120,
+                 p1=0.3,
+                 p2=1.3,
+                 p3=2.3,
+                 break1=0.08,
+                 break2=0.5):
         """
         The Kroupa IMF with two power-law breaks, p1 and p2. See __call__ for
         details.
@@ -154,12 +159,10 @@ class Kroupa(MassFunction):
             The mass breakpoints at which to use the different power laws
         """
 
-
         if integral_form:
             return self.normfactor * self.distr.cdf(m)
         else:
             return self.normfactor * self.distr.pdf(m)
-
 
     def integrate(self, mlow, mhigh, numerical=False):
         """
@@ -170,8 +173,8 @@ class Kroupa(MassFunction):
         if numerical:
             return super(Kroupa, self).integrate(mlow, mhigh)
 
-        return (self.distr.cdf(mhigh) - self.distr.cdf(mlow)) * self.normfactor, 0
-
+        return (self.distr.cdf(mhigh) -
+                self.distr.cdf(mlow)) * self.normfactor, 0
 
     def m_integrate(self, mlow, mhigh, numerical=False, **kwargs):
         """
@@ -183,14 +186,12 @@ class Kroupa(MassFunction):
         if numerical:
             return super(Kroupa, self).m_integrate(mlow, mhigh, **kwargs)
         else:
-            distr1 = distributions.BrokenPowerLaw([-self.p1+1, -self.p2+1,
-                                                   -self.p3+1],
-                                                  [self.mmin, self.break1,
-                                                   self.break2, self.mmax])
-            ratio = distr1.pdf(self.break1)/self.distr.pdf(self.break1)/self.break1
-            return ((distr1.cdf(mhigh)-distr1.cdf(mlow))/ratio, 0)
-
-
+            distr1 = distributions.BrokenPowerLaw(
+                [-self.p1 + 1, -self.p2 + 1, -self.p3 + 1],
+                [self.mmin, self.break1, self.break2, self.mmax])
+            ratio = distr1.pdf(self.break1) / self.distr.pdf(
+                self.break1) / self.break1
+            return ((distr1.cdf(mhigh) - distr1.cdf(mlow)) / ratio, 0)
 
 
 kroupa = Kroupa()
@@ -198,7 +199,7 @@ kroupa = Kroupa()
 
 class Chabrier(MassFunction):
     def __init__(self):
-        self.mmin = 0.57*np.log(10)
+        self.mmin = 0.57 * np.log(10)
         self.multiplier = 0.86
 
     @property
@@ -207,16 +208,22 @@ class Chabrier(MassFunction):
 
     def __call__(self, mass, integral_form=False, **kw):
         if integral_form:
-            return self.distr.cdf(mass)*self.multiplier
+            return self.distr.cdf(mass) * self.multiplier
         else:
-            return self.distr.pdf(mass)*self.multiplier
+            return self.distr.pdf(mass) * self.multiplier
 
 
 chabrier = Chabrier()
 
+
 class Chabrier2005(MassFunction):
-    def __init__(self, lognormal_center=0.2, lognormal_width=0.55*np.log(10),
-                 mmin=0.033, mmax=np.inf, alpha=2.35, mmid=1):
+    def __init__(self,
+                 lognormal_center=0.2,
+                 lognormal_width=0.55 * np.log(10),
+                 mmin=0.033,
+                 mmax=np.inf,
+                 alpha=2.35,
+                 mmid=1):
         # The numbers are from Eqn 3 of
         # https://ui.adsabs.harvard.edu/abs/2005ASSL..327...41C/abstract
         # importantly the lognormal center is the exp(M) where M is the mean of ln(mass)
@@ -230,12 +237,12 @@ class Chabrier2005(MassFunction):
 
     @property
     def distr(self):
-        return distributions.CompositeDistribution(
-            [distributions.TruncatedLogNormal(self.lognormal_center,
-                                              self.lognormal_width,
-                                              self.mmin,
-                                              self.mmid),
-             distributions.PowerLaw(-self.alpha, self.mmid, self.mmax)])
+        return distributions.CompositeDistribution([
+            distributions.TruncatedLogNormal(self.lognormal_center,
+                                             self.lognormal_width, self.mmin,
+                                             self.mmid),
+            distributions.PowerLaw(-self.alpha, self.mmid, self.mmax)
+        ])
 
     def __call__(self, x, integral_form=False, **kw):
         if integral_form:
@@ -274,7 +281,8 @@ def schechter(m, A=1, beta=2, m0=100, integral=False):
     """
     if integral:
         beta -= 1
-    return A*m**-beta * np.exp(-m/m0)
+    return A * m**-beta * np.exp(-m / m0)
+
 
 def modified_schechter(m, m1, **kwargs):
     """
@@ -294,10 +302,12 @@ def modified_schechter(m, m1, **kwargs):
         as a function of that object's mass
         (though you could interpret mass as anything, it's just a number)
     """
-    return schechter(m, **kwargs) * np.exp(-m1/m)
+    return schechter(m, **kwargs) * np.exp(-m1 / m)
+
 
 try:
     import scipy
+
     def schechter_cdf(m, A=1, beta=2, m0=100, mmin=10, mmax=None, npts=1e4):
         """
         Return the CDF value of a given mass for a set mmin, mmax
@@ -307,15 +317,16 @@ try:
         http://www.wolframalpha.com/input/?i=integral%28x^-a+exp%28-x%2Fm%29+dx%29
         """
         if mmax is None:
-            mmax = 10*m0
+            mmax = 10 * m0
 
         # integrate the CDF from the minimum to maximum
-        posint = -mmax**(1-beta) * scipy.special.expn(beta, mmax/m0)
-        negint = -mmin**(1-beta) * scipy.special.expn(beta, mmin/m0)
-        tot = posint-negint
+        posint = -mmax**(1 - beta) * scipy.special.expn(beta, mmax / m0)
+        negint = -mmin**(1 - beta) * scipy.special.expn(beta, mmin / m0)
+        tot = posint - negint
 
         # normalize by the integral
-        ret = (-m**(1-beta) * scipy.special.expn(beta, m/m0) - negint) / tot
+        ret = (-m**(1 - beta) * scipy.special.expn(beta, m / m0) -
+               negint) / tot
 
         return ret
 
@@ -324,36 +335,55 @@ try:
 except ImportError:
     pass
 
+
 def m_integrate(fn=kroupa, bins=np.logspace(-2, 2, 500)):
-    xax = (bins[:-1]+bins[1:])/2.
-    integral = xax*(bins[1:]-bins[:-1]) * (fn(bins[:-1])+fn(bins[1:])) / 2.
+    xax = (bins[:-1] + bins[1:]) / 2.
+    integral = xax * (bins[1:] - bins[:-1]) * (fn(bins[:-1]) +
+                                               fn(bins[1:])) / 2.
 
     return xax, integral
+
 
 def cumint(fn=kroupa, bins=np.logspace(-2, 2, 500)):
     xax, integral = integrate(fn, bins)
     return integral.cumsum() / integral.sum()
 
+
 def m_cumint(fn=kroupa, bins=np.logspace(-2, 2, 500)):
     xax, integral = m_integrate(fn, bins)
     return integral.cumsum() / integral.sum()
 
-massfunctions = {'kroupa': kroupa, 'salpeter': salpeter, 'chabrier': chabrier,
-                 'schechter': schechter, 'modified_schechter': modified_schechter}
+
+massfunctions = {
+    'kroupa': kroupa,
+    'salpeter': salpeter,
+    'chabrier': chabrier,
+    'schechter': schechter,
+    'modified_schechter': modified_schechter
+}
 reverse_mf_dict = {v: k for k, v in iteritems(massfunctions)}
 # salpeter and schechter selections are arbitrary
-mostcommonmass = {'kroupa': 0.08, 'salpeter': 0.01, 'chabrier': 0.23,
-                  'schecter': 0.01, 'modified_schechter': 0.01}
+mostcommonmass = {
+    'kroupa': 0.08,
+    'salpeter': 0.01,
+    'chabrier': 0.23,
+    'schecter': 0.01,
+    'modified_schechter': 0.01
+}
 expectedmass_cache = {}
 
+
 def get_massfunc(massfunc):
-    if isinstance(massfunc, types.FunctionType) or hasattr(massfunc, '__call__'):
+    if isinstance(massfunc, types.FunctionType) or hasattr(
+            massfunc, '__call__'):
         return massfunc
     elif type(massfunc) is str:
         return massfunctions[massfunc]
     else:
-        raise ValueError("massfunc must either be a string in the set %s or a function"
-                         % (", ".join(massfunctions.keys())))
+        raise ValueError(
+            "massfunc must either be a string in the set %s or a function" %
+            (", ".join(massfunctions.keys())))
+
 
 def get_massfunc_name(massfunc):
     if massfunc in reverse_mf_dict:
@@ -365,7 +395,12 @@ def get_massfunc_name(massfunc):
     else:
         raise ValueError("invalid mass function")
 
-def inverse_imf(p, nbins=1000, mmin=None, mmax=None, massfunc='kroupa',
+
+def inverse_imf(p,
+                nbins=1000,
+                mmin=None,
+                mmax=None,
+                massfunc='kroupa',
                 **kwargs):
     """
     Inverse mass function.  Creates a cumulative distribution function from the
@@ -402,15 +437,14 @@ def inverse_imf(p, nbins=1000, mmin=None, mmax=None, massfunc='kroupa',
     mmax = mfc.mmax
 
     ends = np.logspace(np.log10(mmin), np.log10(mmax), nbins)
-    masses = (ends[1:] + ends[:-1])/2.
+    masses = (ends[1:] + ends[:-1]) / 2.
     dm = np.diff(ends)
-
 
     # the full probability distribution function N(M) dm
     mf = mfc(masses, **kwargs)
 
     # integrate by taking the cumulative sum of x dx
-    mfcum = (mf*dm).cumsum()
+    mfcum = (mf * dm).cumsum()
 
     # normalize to sum (this turns into a cdf)
     mfcum /= mfcum.max()
@@ -425,8 +459,14 @@ def inverse_imf(p, nbins=1000, mmin=None, mmax=None, massfunc='kroupa',
     return result
 
 
-def make_cluster(mcluster, massfunc='kroupa', verbose=False, silent=False,
-                 tolerance=0.0, stop_criterion='nearest', mmax=120, mmin=None):
+def make_cluster(mcluster,
+                 massfunc='kroupa',
+                 verbose=False,
+                 silent=False,
+                 tolerance=0.0,
+                 stop_criterion='nearest',
+                 mmax=120,
+                 mmin=None):
     """
     Sample from an IMF to make a cluster.  Returns the masses of all stars in the cluster
 
@@ -469,25 +509,26 @@ def make_cluster(mcluster, massfunc='kroupa', verbose=False, silent=False,
     if verbose:
         print("Expected mass is {0:0.3f}".format(expected_mass))
 
-
     mtot = 0
     masses = []
 
     while mtot < mcluster + tolerance:
         # at least 1 sample, but potentially many more
-        nsamp = int(np.ceil((mcluster+tolerance-mtot) / expected_mass))
+        nsamp = int(np.ceil((mcluster + tolerance - mtot) / expected_mass))
         assert nsamp > 0
         newmasses = mfc.distr.rvs(nsamp)
         masses = np.concatenate([masses, newmasses])
         mtot = masses.sum()
         if verbose:
-            print("Sampled %i new stars.  Total is now %g" % (int(nsamp), mtot))
+            print("Sampled %i new stars.  Total is now %g" %
+                  (int(nsamp), mtot))
 
-        if mtot > mcluster+tolerance: # don't force exact equality; that would yield infinite loop
+        if mtot > mcluster + tolerance:  # don't force exact equality; that would yield infinite loop
             mcum = masses.cumsum()
             if stop_criterion == 'sorted':
                 masses = np.sort(masses)
-                if np.abs(masses[:-1].sum()-mcluster) < np.abs(masses.sum() - mcluster):
+                if np.abs(masses[:-1].sum() - mcluster) < np.abs(masses.sum() -
+                                                                 mcluster):
                     # if the most massive star makes the cluster a worse fit, reject it
                     # (this follows Krumholz+ 2015 appendix A1)
                     last_ind = len(masses) - 1
@@ -504,8 +545,9 @@ def make_cluster(mcluster, massfunc='kroupa', verbose=False, silent=False,
             masses = masses[:last_ind]
             mtot = masses.sum()
             if verbose:
-                print("Selected the first %i out of %i masses to get %g total"
-                      % (last_ind, len(mcum), mtot))
+                print(
+                    "Selected the first %i out of %i masses to get %g total" %
+                    (last_ind, len(mcum), mtot))
             # force the break, because some stopping criteria can push mtot < mcluster
             break
 
@@ -519,7 +561,9 @@ def make_cluster(mcluster, massfunc='kroupa', verbose=False, silent=False,
 
     return masses
 
+
 mass_luminosity_interpolator_cache = {}
+
 
 def mass_luminosity_interpolator(name):
     if name in mass_luminosity_interpolator_cache:
@@ -527,36 +571,45 @@ def mass_luminosity_interpolator(name):
     elif name == 'VGS':
 
         # non-extrapolated
-        vgsMass = [51.3, 44.2, 41.0, 38.1, 35.5, 33.1, 30.8, 28.8, 26.9, 25.1,
-                   23.6, 22.1, 20.8, 19.5, 18.4]
-        vgslogL = [6.154, 6.046, 5.991, 5.934, 5.876, 5.817, 5.756, 5.695,
-                   5.631, 5.566, 5.499, 5.431, 5.360, 5.287, 5.211]
-        vgslogQ = [49.18, 48.99, 48.90, 48.81, 48.72, 48.61, 48.49, 48.34,
-                   48.16, 47.92, 47.63, 47.25, 46.77, 46.23, 45.69]
+        vgsMass = [
+            51.3, 44.2, 41.0, 38.1, 35.5, 33.1, 30.8, 28.8, 26.9, 25.1, 23.6,
+            22.1, 20.8, 19.5, 18.4
+        ]
+        vgslogL = [
+            6.154, 6.046, 5.991, 5.934, 5.876, 5.817, 5.756, 5.695, 5.631,
+            5.566, 5.499, 5.431, 5.360, 5.287, 5.211
+        ]
+        vgslogQ = [
+            49.18, 48.99, 48.90, 48.81, 48.72, 48.61, 48.49, 48.34, 48.16,
+            47.92, 47.63, 47.25, 46.77, 46.23, 45.69
+        ]
         # mass extrapolated
         vgsMe = np.concatenate([
             np.linspace(0.03, 0.43, 100),
             np.linspace(0.43, 2, 100),
-            np.linspace(2, 20, 100),
-            vgsMass[::-1],
-            np.linspace(50, 150, 100)])
+            np.linspace(2, 20, 100), vgsMass[::-1],
+            np.linspace(50, 150, 100)
+        ])
         # log luminosity extrapolated
         vgslogLe = np.concatenate([
-            np.log10(0.23*np.linspace(0.03, 0.43, 100)**2.3),
+            np.log10(0.23 * np.linspace(0.03, 0.43, 100)**2.3),
             np.log10(np.linspace(0.43, 2, 100)**4),
-            np.log10(1.5*np.linspace(2, 20, 100)**3.5),
-            vgslogL[::-1],
-            np.polyval(np.polyfit(np.log10(vgsMass[:3], vgslogL[:3], 1),
-                                  np.log10(np.linspace(50, 150, 100))))])
+            np.log10(1.5 * np.linspace(2, 20, 100)**3.5), vgslogL[::-1],
+            np.polyval(
+                np.polyfit(np.log10(vgsMass[:3], vgslogL[:3], 1),
+                           np.log10(np.linspace(50, 150, 100))))
+        ])
         # log Q (lyman continuum) extrapolated
         vgslogQe = np.concatenate([
-            np.zeros(100), # 0.03-0.43 solar mass stars produce 0 LyC photons
-            np.zeros(100), # 0.43-2.0 solar mass stars produce 0 LyC photons
-            np.polyval(np.polyfit(np.log10(vgsMass[-3:], vgslogQ[-3:], 1),
-                                  np.log10(np.linspace(8, 18.4, 100)))),
+            np.zeros(100),  # 0.03-0.43 solar mass stars produce 0 LyC photons
+            np.zeros(100),  # 0.43-2.0 solar mass stars produce 0 LyC photons
+            np.polyval(
+                np.polyfit(np.log10(vgsMass[-3:], vgslogQ[-3:], 1),
+                           np.log10(np.linspace(8, 18.4, 100)))),
             vgslogQ[::-1],
-            np.polyval(np.polyfit(np.log10(vgsMass[:3], vgslogQ[:3], 1),
-                                  np.log10(np.linspace(50, 150, 100))))
+            np.polyval(
+                np.polyfit(np.log10(vgsMass[:3], vgslogQ[:3], 1),
+                           np.log10(np.linspace(50, 150, 100))))
         ])
 
         mass_luminosity_interpolator_cache[name] = vgsMe, vgslogLe, vgslogQ
@@ -564,7 +617,7 @@ def mass_luminosity_interpolator(name):
         return mass_luminosity_interpolator_cache[name]
     elif name == 'Ekstrom':
         from astroquery.vizier import Vizier
-        Vizier.ROW_LIMIT = 1e7 # effectively infinite
+        Vizier.ROW_LIMIT = 1e7  # effectively infinite
 
         # this query should cache
         tbl = Vizier.get_catalogs('J/A+A/537/A146/iso')[0]
@@ -573,9 +626,9 @@ def mass_luminosity_interpolator(name):
         masses = tbl['Mass'][match]
         lums = tbl['logL'][match]
         mass_0 = 0.033
-        lum_0 = np.log10((mass_0/masses[0])**3.5 * 10**lums[0])
-        mass_f = 200 # extrapolate to 200 Msun...
-        lum_f = np.log10(10**lums[-1] * (mass_f/masses[-1])**1.35)
+        lum_0 = np.log10((mass_0 / masses[0])**3.5 * 10**lums[0])
+        mass_f = 200  # extrapolate to 200 Msun...
+        lum_f = np.log10(10**lums[-1] * (mass_f / masses[-1])**1.35)
 
         masses = np.array([mass_0] + masses.tolist() + [mass_f])
         lums = np.array([lum_0] + lums.tolist() + [lum_f])
@@ -588,6 +641,7 @@ def mass_luminosity_interpolator(name):
         return mass_luminosity_interpolator_cache[name]
     else:
         raise ValueError("Bad grid name {0}".format(name))
+
 
 def lum_of_star(mass, grid='Ekstrom'):
     """
@@ -608,6 +662,7 @@ def lum_of_star(mass, grid='Ekstrom'):
     masses, lums, _ = mass_luminosity_interpolator(grid)
     return np.interp(mass, masses, lums)
 
+
 def lum_of_cluster(masses, grid='Ekstrom'):
     """
     Determine the log of the integrated luminosity of a cluster
@@ -616,9 +671,10 @@ def lum_of_cluster(masses, grid='Ekstrom'):
     masses is a list or array of masses.
     """
     #if max(masses) < 8: return 0
-    logL = lum_of_star(masses, grid=grid) #[masses >= 8])
-    logLtot = np.log10( (10**logL).sum() )
+    logL = lum_of_star(masses, grid=grid)  #[masses >= 8])
+    logLtot = np.log10((10**logL).sum())
     return logLtot
+
 
 def lyc_of_star(mass):
     """
@@ -627,9 +683,10 @@ def lyc_of_star(mass):
 
     returns LogQ
     """
-    masses, _, logQ =  mass_luminosity_interpolator(grid)
+    masses, _, logQ = mass_luminosity_interpolator(grid)
 
     return np.interp(mass, masses, logQ)
+
 
 def lyc_of_cluster(masses):
     """
@@ -640,8 +697,9 @@ def lyc_of_cluster(masses):
     """
     if max(masses) < 8: return 0
     logq = lyc_of_star(masses[masses >= 8])
-    logqtot = np.log10( (10**logq).sum() )
+    logqtot = np.log10((10**logq).sum())
     return logqtot
+
 
 def color_from_mass(mass, outtype=float):
     """
@@ -712,15 +770,18 @@ def color_from_mass(mass, outtype=float):
     if outtype == int:
         return (r, g, b)
     elif outtype == float:
-        return (r/255., g/255., b/255.)
+        return (r / 255., g / 255., b / 255.)
     else:
         raise NotImplementedError
 
+
 def color_of_cluster(cluster, colorfunc=color_from_mass):
-    colors       = np.array([colorfunc(m) for m in cluster])
+    colors = np.array([colorfunc(m) for m in cluster])
     luminosities = 10**np.array([lum_of_star(m) for m in cluster])
-    mean_color = (colors*luminosities[:, None]).sum(axis=0)/luminosities.sum()
+    mean_color = (colors *
+                  luminosities[:, None]).sum(axis=0) / luminosities.sum()
     return mean_color
+
 
 def coolplot(clustermass, massfunc='kroupa', log=True, **kwargs):
     """
@@ -750,17 +811,24 @@ def coolplot(clustermass, massfunc='kroupa', log=True, **kwargs):
     colors: list
         A list of color tuples associated with each star
     """
-    cluster = make_cluster(clustermass, massfunc=massfunc, mmax=massfunc.mmax,
+    cluster = make_cluster(clustermass,
+                           massfunc=massfunc,
+                           mmax=massfunc.mmax,
                            **kwargs)
     colors = [color_from_mass(m) for m in cluster]
     massfunc = get_massfunc(massfunc)
     maxmass = cluster.max()
     pmin = massfunc(maxmass)
     if log:
-        yax = [np.random.rand()*(np.log10(massfunc(m))-np.log10(pmin))
-               + np.log10(pmin) for m in cluster]
+        yax = [
+            np.random.rand() * (np.log10(massfunc(m)) - np.log10(pmin)) +
+            np.log10(pmin) for m in cluster
+        ]
     else:
-        yax = [np.random.rand()*((massfunc(m))/(pmin)) + (pmin) for m in cluster]
+        yax = [
+            np.random.rand() * ((massfunc(m)) / (pmin)) + (pmin)
+            for m in cluster
+        ]
 
     assert all(np.isfinite(yax))
 
@@ -768,7 +836,6 @@ def coolplot(clustermass, massfunc='kroupa', log=True, **kwargs):
 
     # import pylab as pl
     # pl.scatter(cluster, yax, c=colors, s=np.log10(cluster)*5)
-
 
 
 class KoenConvolvedPowerLaw(MassFunction):
@@ -788,8 +855,6 @@ class KoenConvolvedPowerLaw(MassFunction):
     sigma: float or None
         specified spread of error, assumes Normal distribution with mean 0 and variance sigma.
     """
-
-
     def __init__(self, mmin, mmax, gamma, sigma):
         self.mmin = mmin
         self.mmax = mmax
@@ -798,7 +863,7 @@ class KoenConvolvedPowerLaw(MassFunction):
 
     def __call__(self, m, integral_form=False):
         m = np.asarray(m)
-        if self.mmax<self.mmin:
+        if self.mmax < self.mmin:
             raise ValueError("mmax must be greater than mmin")
 
         if integral_form:
@@ -808,24 +873,24 @@ class KoenConvolvedPowerLaw(MassFunction):
             #       mmin, mmax, sigma, and gamma
 
             def error(t):
-                return np.exp(-(t**2)/2)
+                return np.exp(-(t**2) / 2)
 
-            error_coeffecient = 1/np.sqrt(2*np.pi)
+            error_coeffecient = 1 / np.sqrt(2 * np.pi)
 
             def error_integral(y):
-                error_integral = quad(error, -np.inf, (y-self.mmax)/self.sigma)[0]
+                error_integral = quad(error, -np.inf,
+                                      (y - self.mmax) / self.sigma)[0]
                 return error_integral
 
             vector_errorintegral = np.vectorize(error_integral)
             phi = vector_errorintegral(m) * error_coeffecient
 
             def integrand(x, y):
-                return ((self.mmin**-self.gamma - x**-self.gamma) *
-                        np.exp((-1/2)*((y-x)/self.sigma)**2))
+                return ((self.mmin**-self.gamma - x**-self.gamma) * np.exp(
+                    (-1 / 2) * ((y - x) / self.sigma)**2))
 
-            coef = (1 / (self.sigma*np.sqrt(2*np.pi) *
-                         (self.mmin**-self.gamma -
-                          self.mmax**-self.gamma)))
+            coef = (1 / (self.sigma * np.sqrt(2 * np.pi) *
+                         (self.mmin**-self.gamma - self.mmax**-self.gamma)))
 
             def eval_integral(y):
                 integral = quad(integrand, self.mmin, self.mmax, args=(y))[0]
@@ -835,24 +900,24 @@ class KoenConvolvedPowerLaw(MassFunction):
             probability = phi + coef * vector_integral(m)
             return probability
 
-
         else:
             # Returns
             # ------
             # Probability of getting x given the PDF with specified mmin, mmax, sigma, and gamma
             def integrand(x, y):
-                return (x**-(self.gamma+1)) * np.exp(-.5*((y-x)/self.sigma)**2)
+                return (x**-(self.gamma + 1)) * np.exp(-.5 * (
+                    (y - x) / self.sigma)**2)
 
-            coef = (self.gamma/((self.sigma*np.sqrt(2*np.pi)) *
-                                ((self.mmin**-self.gamma) -
-                                 (self.mmax**-self.gamma))))
+            coef = (self.gamma / ((self.sigma * np.sqrt(2 * np.pi)) *
+                                  ((self.mmin**-self.gamma) -
+                                   (self.mmax**-self.gamma))))
 
             def Integral(y):
                 I = quad(integrand, self.mmin, self.mmax, args=(y))[0]
                 return I
 
             vector_I = np.vectorize(Integral)
-            return  coef * vector_I(m)
+            return coef * vector_I(m)
 
 
 class KoenTruePowerLaw(MassFunction):
@@ -873,7 +938,6 @@ class KoenTruePowerLaw(MassFunction):
     gamma: floats
         The specified gamma for the distribution, related to the slope, alpha = -gamma + 1
     """
-
     def __init__(self, mmin, mmax, gamma):
         self.mmin = mmin
         self.mmax = mmax
@@ -888,9 +952,8 @@ class KoenTruePowerLaw(MassFunction):
             # -------
             # Probability that m < x for the given CDF with specified mmin, mmax, sigma, and gamma
             # True for L<=x
-            pdf = ((self.mmin**-self.gamma -
-                    np.power(m, -self.gamma))/self.mmin**-self.gamma -
-                   self.mmax**-self.gamma)
+            pdf = ((self.mmin**-self.gamma - np.power(m, -self.gamma)) /
+                   self.mmin**-self.gamma - self.mmax**-self.gamma)
             return_value = (pdf * ((m > self.mmin) & (m < self.mmax)) + 1.0 *
                             (m >= self.mmax) + 0 * (m < self.mmin))
             return return_value
@@ -900,10 +963,8 @@ class KoenTruePowerLaw(MassFunction):
             # ------
             # Probability of getting x given the PDF with specified mmin, mmax, and gamma
             # Answers it gives are true from mmin<=x<=mmax
-            cdf = (self.gamma*np.power(m,
-                                       -(self.gamma+1))/(self.mmin**-self.gamma
-                                                         -
-                                                         self.mmax**-self.gamma))
+            cdf = (self.gamma * np.power(m, -(self.gamma + 1)) /
+                   (self.mmin**-self.gamma - self.mmax**-self.gamma))
             return_value = (cdf * ((m > self.mmin) & (m < self.mmax)) + 0 *
                             (m > self.mmax) + 0 * (m < self.mmin))
             return return_value

--- a/imf/tests/test_distributions.py
+++ b/imf/tests/test_distributions.py
@@ -173,16 +173,16 @@ def test_integral():
     distrs = [
         D.TruncatedLogNormal(1, 1, left, right),
         D.PowerLaw(-2, left, right),
-        D.BrokenPowerLaw([-2, -1.1, -3],
-                         [left, .6 * left + .3 * right, .3 * left + .6 * right, right]),
+        D.BrokenPowerLaw(
+            [-2, -1.1, -3],
+            [left, .6 * left + .3 * right, .3 * left + .6 * right, right]),
         D.CompositeDistribution([
             D.TruncatedLogNormal(1, 1, left, .75 * left + .25 * right),
             D.PowerLaw(-2, .75 * left + .25 * right, .5 * left + .5 * right),
-            D.TruncatedLogNormal(1, 1,
-                                 .5 * left + .5 * right,
+            D.TruncatedLogNormal(1, 1, .5 * left + .5 * right,
                                  .25 * left + .75 * right),
-            D.PowerLaw(-2, .25 * left + .75 * right, right)]
-        )
+            D.PowerLaw(-2, .25 * left + .75 * right, right)
+        ])
     ]
     for curd in distrs:
         integralcheck_many(curd, left, right)

--- a/imf/tests/test_imf.py
+++ b/imf/tests/test_imf.py
@@ -7,13 +7,13 @@ from .. import imf
 from ..imf import kroupa, chabrier2005
 
 
-@pytest.mark.parametrize(('inp', 'out', 'rtol', 'atol'),
-                         [(0.05, 5.6159, 1e-3, 1e-3),
-                          (1.5, 0.0359, 1e-4, 1e-4),
-                          (1.0, 0.0914, 1e-4, 1e-4),
-                          (3.0, 0.0073, 1e-4, 1e-4),
-                          (1, 0.0914, 1e-4, 1e-4),
-                          (3, 0.0073, 1e-4, 1e-4)])
+@pytest.mark.parametrize(
+    ('inp', 'out', 'rtol', 'atol'), [(0.05, 5.6159, 1e-3, 1e-3),
+                                     (1.5, 0.0359, 1e-4, 1e-4),
+                                     (1.0, 0.0914, 1e-4, 1e-4),
+                                     (3.0, 0.0073, 1e-4, 1e-4),
+                                     (1, 0.0914, 1e-4, 1e-4),
+                                     (3, 0.0073, 1e-4, 1e-4)])
 def test_kroupa_val(inp, out, rtol, atol):
     kroupa = imf.Kroupa()
     np.testing.assert_allclose(kroupa(inp), out, rtol=rtol, atol=atol)
@@ -62,9 +62,10 @@ def test_kroupa_mintegral(mlow, mhigh):
         assert anl != 0
 
 
-@pytest.mark.parametrize(('mlow', 'mhigh'),
-                         itertools.product((0.033, 0.01, 0.08, 0.1, 0.5, 1.0, 0.03),
-                                           (0.02, 0.05, 0.08, 0.4, 0.5, 1.0, 120)))
+@pytest.mark.parametrize(
+    ('mlow', 'mhigh'),
+    itertools.product((0.033, 0.01, 0.08, 0.1, 0.5, 1.0, 0.03),
+                      (0.02, 0.05, 0.08, 0.4, 0.5, 1.0, 120)))
 def test_chabrier_integral(mlow, mhigh):
     if mlow >= mhigh:
         pytest.skip("mmin >= mmax")
@@ -92,19 +93,22 @@ def test_make_cluster():
 
 
 def test_kroupa_inverses():
-    assert np.abs(imf.inverse_imf(0, massfunc=imf.Kroupa(), mmin=0.01) - 0.01) < 2e-3
-    assert np.abs(imf.inverse_imf(0, massfunc=imf.Kroupa(mmin=0.01)) - 0.01) < 2e-3
-    assert np.abs(imf.inverse_imf(1, massfunc=imf.Kroupa(), mmax=200) - 200) < 1
+    assert np.abs(imf.inverse_imf(0, massfunc=imf.Kroupa(), mmin=0.01) -
+                  0.01) < 2e-3
+    assert np.abs(imf.inverse_imf(0, massfunc=imf.Kroupa(mmin=0.01)) -
+                  0.01) < 2e-3
+    assert np.abs(imf.inverse_imf(1, massfunc=imf.Kroupa(), mmax=200) -
+                  200) < 1
     assert np.abs(imf.inverse_imf(1, massfunc=imf.Kroupa(mmax=200)) - 200) < 1
 
 
-@pytest.mark.parametrize(('inp', 'out', 'rtol', 'atol'),
-                         [(0.05, 5.6159, 1e-3, 1e-3),
-                          (1.5, 0.0359, 1e-4, 1e-4),
-                          (1.0, 0.0914, 1e-4, 1e-4),
-                          (3.0, 0.0073, 1e-4, 1e-4),
-                          (1, 0.0914, 1e-4, 1e-4),
-                          (3, 0.0073, 1e-4, 1e-4)])
+@pytest.mark.parametrize(
+    ('inp', 'out', 'rtol', 'atol'), [(0.05, 5.6159, 1e-3, 1e-3),
+                                     (1.5, 0.0359, 1e-4, 1e-4),
+                                     (1.0, 0.0914, 1e-4, 1e-4),
+                                     (3.0, 0.0073, 1e-4, 1e-4),
+                                     (1, 0.0914, 1e-4, 1e-4),
+                                     (3, 0.0073, 1e-4, 1e-4)])
 def test_kroupa_val_unchanged(inp, out, rtol, atol):
     # regression: make sure that imf.kroupa = imf.Kroupa
     kroupa = imf.Kroupa()


### PR DESCRIPTION
Several fixes addressing #21, #19, #18 
Also run the code through yapf formatter.

I.e now when specifying invalid mmin for kroupa a proper error is raised
```python
In [5]: cl = imf.make_cluster(1000,massfunc='kroupa',mmin=1)
ValueError: Power law break-points must be monotonic
```
also the global imf objects are not modified since get_massfunc() returns new instances

Also mmin is supported now for chabrier
```python
In [13]: imf.make_cluster(1000,massfunc='chabrier',mmin=10).mean()
Total cluster mass is 1002.2 (limit was 1000)
Out[13]: 16.70338008453732

In [14]: imf.make_cluster(1000,massfunc='chabrier',mmin=1).mean()
Total cluster mass is 1000.38 (limit was 1000)
Out[14]: 2.2684320853833024
```