### PR TITLE
Chabrier distribution coefficients

### DIFF
--- a/examples/chabrier_comparisons.py
+++ b/examples/chabrier_comparisons.py
@@ -1,0 +1,37 @@
+"""
+Compare the Chabrier distribution pulled from eqn 18 of Chabrier 2003 to
+that quoted in McKee & Offner 2010 as "Chabrier 2005"
+"""
+import imf
+import numpy as np
+import pylab as pl
+
+chabrier = imf.chabrierpowerlaw
+chabrier2005 = imf.ChabrierPowerLaw(lognormal_width=0.55*np.log(10),
+                                    lognormal_center=0.2,
+                                    alpha=2.35)
+
+masses = np.geomspace(0.01, 10, 1000)
+pl.figure(1)
+pl.loglog(masses, chabrier(masses), label='Chabrier 2003 eqn 18')
+pl.loglog(masses, chabrier2005(masses), label='Chabrier 2005 via McKee & Offner 2010')
+pl.xlabel("Mass")
+pl.ylabel("$\\xi \\equiv dN/dM$")
+pl.legend(loc='best')
+pl.savefig("Chabrier2003v2005.png")
+
+pl.figure(2)
+pl.loglog(masses, chabrier2005(masses) - chabrier(masses), label='C03-C05')
+pl.loglog(masses, chabrier(masses) - chabrier2005(masses), label='C05-C03')
+pl.xlabel("Mass")
+pl.ylabel("$\\xi_1 - \\xi_2$")
+pl.legend(loc='best')
+pl.savefig("Chabrier2003v2005_diff.png")
+
+pl.figure(3)
+pl.loglog(masses, (chabrier2005(masses) - chabrier(masses))/chabrier(masses), label='(C03-C05)/C03')
+pl.loglog(masses, (chabrier(masses) - chabrier2005(masses))/chabrier(masses), label='(C05-C03)/C03')
+pl.xlabel("Mass")
+pl.ylabel("$(\\xi_1-\\xi_2)/\\xi_1$")
+pl.legend(loc='best')
+pl.savefig("Chabrier2003v2005_relativediff.png")

--- a/imf/imf.py
+++ b/imf/imf.py
@@ -395,6 +395,8 @@ salpeter = Salpeter()
 kroupa = Kroupa()
 lognormal = chabrierlognormal = ChabrierLogNormal()
 chabrier = chabrierpowerlaw = ChabrierPowerLaw()
+chabrier2005 = ChabrierPowerLaw(lognormal_width=0.55*np.log(10),
+                                lognormal_center=0.2, alpha=2.35)
 
 massfunctions = {'kroupa': Kroupa, 'salpeter': Salpeter,
                  'chabrierlognormal': ChabrierLogNormal,


### PR DESCRIPTION
Figures comparing the Chabrier distribution coefficients used in McKee & Offner 2010 (and formerly the defaults) to those from Chabrier 2003.

The differences in likelihood can be substantial, though likely most of the net effects are fairly negligible.  Nonetheless, to maximize backward compatibility / minimize unforeseen downstream user error, I think it's best we keep the `chabrier2005` form around.  It's just as valid, just slightly less 'canonical'.
![Chabrier2003v2005_relativediff](https://user-images.githubusercontent.com/143715/158876980-8efb692d-6550-4a65-842d-46485068590f.png)
![Chabrier2003v2005_diff](https://user-images.githubusercontent.com/143715/158876981-706e0993-5a17-4b26-b472-bb0787b9c5b8.png)
![Chabrier2003v2005](https://user-images.githubusercontent.com/143715/158876985-3949ab69-5ca5-4468-91c8-4ec9ea8d018c.png)

